### PR TITLE
refactor Apex.Format.Utils

### DIFF
--- a/lib/apex/format/utils.ex
+++ b/lib/apex/format/utils.ex
@@ -9,9 +9,7 @@ defmodule Apex.Format.Utils do
   end
 
   def separator_line(str, length \\ 100) do
-    Stream.repeatedly(fn -> str end)
-      |> Enum.take(length)
-      |> Enum.join
+    String.duplicate(str, length)
       |> Apex.Format.Color.escape(:yellow)
   end
 
@@ -20,18 +18,14 @@ defmodule Apex.Format.Utils do
   end
 
   def indent(options) do
-     0..(level(options) * step(options))
-      |> Enum.uniq
-      |> Enum.drop(1)
-      |> Enum.map(fn(_) -> "\s" end)
-      |> Enum.join
+    String.duplicate("\s", level(options) * step(options))
   end
 
   defp step(options) do
-    options[:indent] || @default_indent
+    Keyword.get(options, :indent, @default_indent)
   end
 
   defp level(options)  do
-    Keyword.get(options, :indent_level) || @default_level
+    Keyword.get(options, :indent_level, @default_level)
   end
 end

--- a/test/format/utils_test.exs
+++ b/test/format/utils_test.exs
@@ -29,4 +29,8 @@ defmodule Apex.Format.Utils.Test do
   test "#colorize should color when it's asked for it" do
     assert colorize("A", 1)  == "\e[34mA\e[0m"
   end
+
+  test "#separator_line" do
+    assert separator_line("-", 5) == "\e[33m-----\e[0m"
+  end
 end


### PR DESCRIPTION
I noticed that some places in Apex.Format.Utils can be rewritten and expressed clearly with Elixir's built-in methods.
