### PR TITLE
Fixes test broken by last fix.

### DIFF
--- a/test/format_test.exs
+++ b/test/format_test.exs
@@ -49,7 +49,7 @@ defmodule Apex.Format.Test do
   end
 
   test "Can format empty tuples" do
-    assert format({}, color: false) == "{}"
+    assert format({}, color: false) == "{}\n"
   end
 
   test "Can format tuples that don't start with an atom" do


### PR DESCRIPTION
Fix included newline in the function but  not in the test it resulted in this failure:

```
  1) test Can format empty tuples (Apex.Format.Test)
     test/format_test.exs:51
     Assertion with == failed
     code: format({}, color: false) == "{}"
     lhs:  "{}\n"
     rhs:  "{}"
     stacktrace:
       test/format_test.exs:52
```