### PR TITLE
Add support for printing invalid UTF-8 strings as binaries.

### DIFF
--- a/lib/apex/format.ex
+++ b/lib/apex/format.ex
@@ -15,7 +15,12 @@ defimpl Apex.Format, for: BitString do
   import Apex.Format.Utils
 
   def format(data, options \\ []) do
-    colorize("\"#{data}\"", data, options) <> new_line
+    case String.valid?(data) do
+      true ->
+        colorize("\"#{data}\"", data, options) <> new_line
+      false ->
+        colorize("#{inspect data}", data, options) <> new_line
+    end
   end
 end
 


### PR DESCRIPTION
I made a quick patch to print invalid UTF-8 as binaries.

Before:

    iex(1)> Apex.ap <<128, 1, 2, 3>>
    ** (UnicodeConversionError) invalid encoding starting at <<128, 1, 2, 3, 34>>
        (elixir) lib/io.ex:356: IO.chardata_to_string/1
                 lib/apex/format.ex:18: Apex.Format.BitString.format/2
                 lib/apex.ex:8: Apex.ap/2

After:

    iex(2)> Apex.ap <<128, 1, 2, 3>>
    <<128, 1, 2, 3>>

Now you can dump structs with weird binary payloads :) (ASN.1, etc)