### PR TITLE
Adding 'Port' implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ If the numbering is not for you, you can turn it off via `Apex.ap(data, numbers:
 * List
 * Range
 * PID
+* Port
 * Function
 * HashDict
 * HashSet

--- a/lib/apex/format.ex
+++ b/lib/apex/format.ex
@@ -70,6 +70,14 @@ defimpl Apex.Format, for: PID do
   end
 end
 
+defimpl Apex.Format, for: Port do
+  import Apex.Format.Utils
+
+  def format(data, options \\ []) do
+    colorize(inspect(data), data, options) <> new_line
+  end
+end
+
 defimpl Apex.Format, for: Function do
   import Apex.Format.Utils
 

--- a/lib/apex/format/color.ex
+++ b/lib/apex/format/color.ex
@@ -19,6 +19,7 @@ defmodule Apex.Format.Color do
   defp color(data) when is_function(data), do: :magenta
   defp color(data) when is_list(data),     do: :white
   defp color(data) when is_pid(data),      do: :yellow
+  defp color(data) when is_port(data),     do: [:green, :bright]
   defp color({Range, _, _}),               do: :green
   defp color({HashSet, _, _}),             do: :white
   defp color({HashDict, _, _}),            do: :white

--- a/test/format_test.exs
+++ b/test/format_test.exs
@@ -78,6 +78,10 @@ defmodule Apex.Format.Test do
     assert format(self, color: false) =~ ~r(#PID<0.\d+.0>\n)
   end
 
+    test "Can format port" do
+    assert format(Port.list |> List.first, color: false) =~ ~r(#Port<0.\d+>\n)
+  end
+
   test "Can format function" do
     f = fn(a) -> "#{a}" end
     assert format(f, color: false) =~ ~r(#Function<0.\d+/1 in Apex.Format.Test.test Can format function/1>\n)


### PR DESCRIPTION
This Pull Request adds an Apex.Format protocol implementation for the built-in standard `Port` datatype, that is mostly used to keep references to external things (socket connections, file handlers, etc).
