### PR TITLE
Add parentheses to zero-arity function calls

### DIFF
--- a/lib/apex/format.ex
+++ b/lib/apex/format.ex
@@ -7,7 +7,7 @@ defimpl Apex.Format, for: Reference do
   import Apex.Format.Utils
 
   def format(data, options \\ []) do
-    colorize(inspect(data), data, options) <> new_line
+    colorize(inspect(data), data, options) <> new_line()
   end
 end
 
@@ -17,9 +17,9 @@ defimpl Apex.Format, for: BitString do
   def format(data, options \\ []) do
     case String.valid?(data) do
       true ->
-        colorize("\"#{data}\"", data, options) <> new_line
+        colorize("\"#{data}\"", data, options) <> new_line()
       false ->
-        colorize("#{inspect data}", data, options) <> new_line
+        colorize("#{inspect data}", data, options) <> new_line()
     end
   end
 end
@@ -28,7 +28,7 @@ defimpl Apex.Format, for: Integer do
   import Apex.Format.Utils
 
   def format(data, options \\ []) do
-    colorize("#{data}", data, options) <> new_line
+    colorize("#{data}", data, options) <> new_line()
   end
 end
 
@@ -36,7 +36,7 @@ defimpl Apex.Format, for: Float do
   import Apex.Format.Utils
 
   def format(data, options \\ []) do
-    colorize("#{Float.to_string(data, decimals: 15, compact: true)}", data, options) <> new_line
+    colorize("#{Float.to_string(data, decimals: 15, compact: true)}", data, options) <> new_line()
   end
 end
 
@@ -46,11 +46,11 @@ defimpl Apex.Format, for: Atom do
   def format(data, options \\ [])
 
   def format(data, options) when data in [true, false, nil] do
-    colorize(Atom.to_string(data), data, options) <> new_line
+    colorize(Atom.to_string(data), data, options) <> new_line()
   end
 
   def format(data, options) do
-    colorize(":" <> Atom.to_string(data), data, options) <> new_line
+    colorize(":" <> Atom.to_string(data), data, options) <> new_line()
   end
 end
 
@@ -60,7 +60,7 @@ defimpl Apex.Format, for: List do
   def format(data, options \\ [])
 
   def format([], options) do
-    colorize("[]", [], options) <> new_line
+    colorize("[]", [], options) <> new_line()
   end
 
   def format(data, options) do
@@ -72,7 +72,7 @@ defimpl Apex.Format, for: Range do
   import Apex.Format.Utils
 
   def format(d = %{__struct__: name, first: lower_bound, last: upper_bound}, options \\ []) do
-    colorize("##{name} #{lower_bound}..#{upper_bound}", d, options) <> new_line
+    colorize("##{name} #{lower_bound}..#{upper_bound}", d, options) <> new_line()
   end
 end
 
@@ -80,7 +80,7 @@ defimpl Apex.Format, for: PID do
   import Apex.Format.Utils
 
   def format(data, options \\ []) do
-    colorize(inspect(data), data, options) <> new_line
+    colorize(inspect(data), data, options) <> new_line()
   end
 end
 
@@ -88,7 +88,7 @@ defimpl Apex.Format, for: Port do
   import Apex.Format.Utils
 
   def format(data, options \\ []) do
-    colorize(inspect(data), data, options) <> new_line
+    colorize(inspect(data), data, options) <> new_line()
   end
 end
 
@@ -96,7 +96,7 @@ defimpl Apex.Format, for: Function do
   import Apex.Format.Utils
 
   def format(data, options \\ []) do
-    colorize(inspect(data), data, options) <> new_line
+    colorize(inspect(data), data, options) <> new_line()
   end
 end
 
@@ -131,7 +131,7 @@ defimpl Apex.Format, for: Map do
   def format(data, options \\ [])
 
   def format(data, options) when data == %{} do
-    colorize("%{}", %{}, options) <> new_line
+    colorize("%{}", %{}, options) <> new_line()
   end
 
   def format(data, options) do

--- a/lib/apex/format/color.ex
+++ b/lib/apex/format/color.ex
@@ -38,7 +38,7 @@ defmodule Apex.Format.Color do
   end
 
   def default_color(id) do
-    Map.get(default_colors, id)
+    Map.get(default_colors(), id)
   end
 
   def customization_file do
@@ -46,7 +46,7 @@ defmodule Apex.Format.Color do
   end
 
   def load_color_customizations_from_apexrc do
-    with {:ok, contents }        <- File.read(customization_file),
+    with {:ok, contents }        <- File.read(customization_file()),
          {%{colors: colors}, _}  when is_map(colors) <- Code.eval_string(contents, [], __ENV__) do
            colors
          else

--- a/lib/apex/format/seq.ex
+++ b/lib/apex/format/seq.ex
@@ -12,8 +12,8 @@ defmodule Apex.Format.Seq do
   end
 
   def format(data, options, config \\ []) do
-    pre  =  start_token(config) <> new_line
-    post =  indent(options) <> end_token(config) <> new_line
+    pre  = start_token(config) <> new_line()
+    post = indent(options) <> end_token(config) <> new_line()
     pre <> do_format(data, next_indent_level(options), config) <> post
   end
 

--- a/lib/apex/format/tuple.ex
+++ b/lib/apex/format/tuple.ex
@@ -10,7 +10,7 @@ defimpl Apex.Format, for: Tuple do
     colorize("#{key}: ", key, options) <> Apex.Format.format(value, options)
   end
 
-  defp do_format({}, _options), do: "{}" <> new_line
+  defp do_format({}, _options), do: "{}" <> new_line()
   defp do_format(data, options) do
     seq = Tuple.to_list(data)
     head = hd(seq)

--- a/mix.exs
+++ b/mix.exs
@@ -6,9 +6,9 @@ defmodule Apex.Mixfile do
       version: "0.6.0",
       elixir: "~> 1.2 or ~> 1.3",
       build_per_environment: false,
-      description: description,
-      package: package,
-      deps: deps ]
+      description: description(),
+      package: package(),
+      deps: deps()]
   end
 
   def application do


### PR DESCRIPTION
This fixes almost all warnings to be introduced in Elixir 1.4.