### PR TITLE
Update Float.to_string/2 to :erlang.float_to_binary/2 per deprecation warnings

### DIFF
--- a/lib/apex/format.ex
+++ b/lib/apex/format.ex
@@ -36,7 +36,7 @@ defimpl Apex.Format, for: Float do
   import Apex.Format.Utils
 
   def format(data, options \\ []) do
-    colorize("#{Float.to_string(data, decimals: 15, compact: true)}", data, options) <> new_line()
+    colorize("#{:erlang.float_to_binary(data, [:compact, decimals: 15])}", data, options) <> new_line()
   end
 end
 


### PR DESCRIPTION
Nothing like a library logging warnings for every float, amirite?

Deprecation context [here](https://github.com/elixir-lang/elixir/issues/3413)