### PR TITLE
Added keys_to_atoms option for display maps

### DIFF
--- a/lib/apex/format.ex
+++ b/lib/apex/format.ex
@@ -116,12 +116,26 @@ defimpl Apex.Format, for: Map do
   end
 
   def format(data, options) do
+    data = convert_keys_to_atoms(data, options)
     Apex.Format.Seq.format(
       Map.to_list(data),
       options,
       start_token: "\%{",
       end_token: "}",
       numbers: false) |> colorize(data, options)
+  end
+
+  defp keys_to_atoms?(options) do
+    options[:keys_to_atoms] == true
+  end
+
+  defp convert_keys_to_atoms(data, options) do
+    data =
+    if keys_to_atoms?(options) do
+      Map.new(data, fn {k,v} -> {String.to_atom(k), v} end)
+    else
+      data
+    end
   end
 end
 

--- a/test/format_test.exs
+++ b/test/format_test.exs
@@ -172,4 +172,76 @@ defmodule Apex.Format.Test do
     ]
     """
   end
+
+  test "Can format maps and change keys to atoms" do
+    data = %{"foo" => "bar", "bar" => "baz",
+      "mappings" => [
+          %{"foo1" => "bar1", "bar1" => "baz1" },
+          %{"foo2" => "bar2", "bar2" => "baz2" }
+      ]
+    }
+    assert format(data, keys_to_atoms: true, color: false) == """
+    %{
+      bar: "baz"
+      foo: "bar"
+      mappings: [
+        [0] %{
+          bar1: "baz1"
+          foo1: "bar1"
+        }
+        [1] %{
+          bar2: "baz2"
+          foo2: "bar2"
+        }
+      ]
+    }
+    """
+  end
+
+  test "Can format maps and leave keys as is" do
+    data = %{"foo" => "bar", "bar" => "baz",
+      "mappings" => [
+          %{"foo1" => "bar1", "bar1" => "baz1" },
+          %{"foo2" => "bar2", "bar2" => "baz2" }
+      ]
+    }
+    assert format(data, keys_to_atoms: false, color: false) == """
+    %{
+      {
+        [0] "bar"
+        [1] "baz"
+      }
+      {
+        [0] "foo"
+        [1] "bar"
+      }
+      {
+        [0] "mappings"
+        [1] [
+          [0] %{
+            {
+              [0] "bar1"
+              [1] "baz1"
+            }
+            {
+              [0] "foo1"
+              [1] "bar1"
+            }
+          }
+          [1] %{
+            {
+              [0] "bar2"
+              [1] "baz2"
+            }
+            {
+              [0] "foo2"
+              [1] "bar2"
+            }
+          }
+        ]
+      }
+    }
+    """
+  end
+
 end


### PR DESCRIPTION
We use lots of maps with string keys instead of atoms because we have a lot of dynamic data.  I wanted to be able to view these maps using your library for debugging purposes, but its annoying to see string keys as [0] [1] pairs.  So I added an option keys_to_atoms which when set to true, automatically converts the string keys to atoms.  Would never use this in production code, because atoms would take up memory, but great for testing.

Only problem is, I could not figure out how to modify the code to allow this option to be set in the config, similar to how the numbers option works.  So could use some help/guidance on best way to do that with your code.

Thanks and I look forward to hearing from you.