### PR TITLE
Updates for Elixir 1.5

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Apex.Mixfile do
   def project do
     [ app: :apex,
       version: "1.0.0",
-      elixir: "~> 1.3 or ~> 1.4",
+      elixir: "~> 1.3 or ~> 1.4 or ~> 1.5",
       build_per_environment: false,
       description: description(),
       package: package(),

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"earmark": {:hex, :earmark, "1.0.2", "a0b0904d74ecc14da8bd2e6e0248e1a409a2bc91aade75fcf428125603de3853", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}
+%{"earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.17.1", "39f777415e769992e6732d9589dc5846ea587f01412241f4a774664c746affbb", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]}}


### PR DESCRIPTION
I get a warning when compiling in Elixir 1.5 because it's marked as unsupported in the project description. As far as I can tell, though, there's no 1.5 compatibility problems.

Besides marking 1.5 as OK, I also upgraded mix.lock. `ex_doc` and `earmark` both have some updates that include quieting some warnings that are new in Elixir 1.5.
