### PR TITLE
Fixes to test-running

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule Apex.Mixfile do
 
   defp deps do
     [
-      {:ex_doc, ">= 0.0.0", only: :dev}
+      {:ex_doc, ">= 0.0.0", only: [:dev, :test]}
     ]
   end
 

--- a/test/format_test.exs
+++ b/test/format_test.exs
@@ -4,7 +4,7 @@ defmodule Apex.Format.Test do
 
   test "Can format references" do
     reference = make_ref()
-    assert format(reference, color: false) =~ ~r/#Reference<\d\.\d\.\d\.\d+>/
+    assert format(reference, color: false) =~ ~r/#Reference<\d+\.\d+\.\d+\.\d+>/
   end
 
   test "Can format a list of strings" do
@@ -108,7 +108,7 @@ defmodule Apex.Format.Test do
 
   test "Can format function" do
     f = fn(a) -> "#{a}" end
-    assert format(f, color: false) =~ ~r(#Function<0.\d+/1 in Apex.Format.Test.test Can format function/1>\n)
+    assert format(f, color: false) =~ ~r(#Function<0.\d+/1 in Apex.Format.Test."test Can format function"/1>\n)
   end
 
   test "Can format MapSets" do


### PR DESCRIPTION
On my Mac, I'm seeing a few test failures. I saw this testing with Elixir 1.4.2 (I'm running 1.5.1 as my main Elixir, so it's possible that I didn't force Elixir 1.4.2 properly.)

- `mix test` sometimes complains about not finding the `ex_doc` application. `mix deps.get && mix compile && mix test` triggers it for me.
- refs can have more than one digit: 
```
  1) test Can format references (Apex.Format.Test)
     test/format_test.exs:5
     Assertion with =~ failed
     code:  assert format(reference, color: false) =~ ~r"#Reference<\\d\\.\\d\\.\\d\\.\\d+>"
     left:  "#Reference<0.2908390478.3650879496.83763>\n"
     right: ~r/#Reference<\d\.\d\.\d\.\d+>/
     stacktrace:
       test/format_test.exs:7: (test)
```
- the function within a test block gets formatted with quotes:
```
  2) test Can format function (Apex.Format.Test)
     test/format_test.exs:109
     Assertion with =~ failed
     code:  assert format(f, color: false) =~ ~r"#Function<0.\\d+/1 in Apex.Format.Test.test Can format function/1>\\n"
     left:  "#Function<0.131963555/1 in Apex.Format.Test.\"test Can format function\"/1>\n"
     right: ~r/#Function<0.\d+\/1 in Apex.Format.Test.test Can format function\/1>\n/
     stacktrace:
       test/format_test.exs:111: (test)
```