### PR TITLE
allow IO.inspect like labels for Apex.ap

### DIFF
--- a/lib/apex.ex
+++ b/lib/apex.ex
@@ -6,7 +6,10 @@ defmodule Apex do
   """
   def ap(data, options \\ []) do
     formatted = Apex.Format.format(data, options)
-    IO.puts(formatted)
+    case Keyword.get(options, :label) do
+      nil -> IO.puts(formatted)
+      label -> IO.puts(label <> ": " <> formatted)
+    end
     data
   end
 end

--- a/test/apex_test.exs
+++ b/test/apex_test.exs
@@ -1,0 +1,31 @@
+defmodule Apex.Test do
+  use ExUnit.Case
+  import Apex
+  import ExUnit.CaptureIO
+
+  test "#ap without label" do
+    output = capture_io(fn ->
+      ap([first_name: "John", last_name: "Doe"], color: false)
+    end)
+    assert output == """
+    [
+      [0] first_name: "John"
+      [1] last_name: "Doe"
+    ]
+
+    """
+  end
+
+  test "#ap with label" do
+    output = capture_io(fn ->
+      ap([first_name: "John", last_name: "Doe"], color: false, label: "some label")
+    end)
+    assert output == """
+    some label: [
+      [0] first_name: "John"
+      [1] last_name: "Doe"
+    ]
+
+    """
+  end
+end


### PR DESCRIPTION
using `IO.inspect` we can apply labels like this:

    some_input
    |> IO.inspect(label: "before")
    |> some_function
    |> IO.inspect(label: "between")
    |> other_function
    |> IO.inspect(label: "after")

which is not (yet) possible using `Apex.ap` - which would be really nice, since we already got the same behavior as `IO.inspect` (returning the original value so you can continue your pipes)

wdyt @BjRo ?